### PR TITLE
Use ComboBox for scenario selection and enable word wrap on description Labels

### DIFF
--- a/JakaCtrl/ui_builder.py
+++ b/JakaCtrl/ui_builder.py
@@ -205,16 +205,25 @@ class UIBuilder:
                     ui.Label("Scenario Name:",
                             style={'color': self.btyellow},
                             width=50)
-                    self._scenario_name_btn = Button(
-                        self._scenario_name, mouse_pressed_fn=self._change_scenario_name,
-                        style={'background_color': self.dkblue}
+
+                    self._scenario_name_combobox = ui.ComboBox(
+                        style={'background_color': self.dkblue, "font_size": 22},
+                        name="Scenario Name"
                     )
+                    for s_name in self._scenario_names:
+                        self._scenario_name_combobox.model.append_child_item(None, ui.SimpleStringModel(s_name))
+                    
+                    self._scenario_name_combobox.model.get_item_value_model().set_value(self._scenario_name)
+                    self._scenario_name_combobox.model.add_item_changed_fn(self._combobox_change_scenario_name)
+
                 with ui.HStack(style=get_style(), spacing=5, height=0):
                     ui.Label("Scenario Desc:",
                             style={'color': self.btyellow},
                             width=50)
-                    self._scenario_desc_lab = ui.Label(ScenarioBase.get_scenario_desc(self._scenario_name),
-                        style={'color': self.btwhite}
+                    self._scenario_desc_lab = ui.Label(
+                        ScenarioBase.get_scenario_desc(self._scenario_name),
+                        style={'color': self.btwhite},
+                        word_wrap=True
                     )
                 with ui.HStack(style=get_style(), spacing=5, height=0):
                     ui.Label("Robot Name:",
@@ -235,8 +244,10 @@ class UIBuilder:
                     ui.Label("Robot Desc:",
                             style={'color': self.btyellow},
                             width=50)
-                    self._robot_desc_lab = ui.Label(ScenarioBase.get_robot_desc(self._robot_name),
-                        style={'color': self.btwhite}
+                    self._robot_desc_lab = ui.Label(
+                        ScenarioBase.get_robot_desc(self._robot_name),
+                        style={'color': self.btwhite},
+                        word_wrap=True
                     )
                 with ui.HStack(style=get_style(), spacing=5, height=0):
                     ui.Label("Mode:",
@@ -882,8 +893,21 @@ class UIBuilder:
 
     def _change_scenario_name(self, x, y, b, m):
         self._scenario_name = self.get_next_val_safe(self._scenario_names, self._scenario_name, self.binc[b])
-        self._scenario_name_btn.text = self._scenario_name
+        # self._scenario_name_btn.text = self._scenario_name
         self._scenario_desc_lab.text = ScenarioBase.get_scenario_desc(self._scenario_name)
+        if not ScenarioBase.can_handle_robot(self._scenario_name, self._robot_name):
+            self._robot_name = self.find_valid_robot_name(self._scenario_name, self._robot_name, 1)
+            self._robot_btn.text = self._robot_name
+            self._robot_desc_lab.text = ScenarioBase.get_robot_desc(self._robot_name)
+
+    def _combobox_change_scenario_name(self, item_model, item):
+        item_index: int = item_model.get_item_value_model().get_value_as_int()
+        selected_scenario: str = self._scenario_names[item_index]
+
+        print(f"_combobox_change_scenario_name {selected_scenario}")
+        self._scenario_name = selected_scenario
+        # self._scenario_name_btn.text = selected_scenario
+        self._scenario_desc_lab.text = ScenarioBase.get_scenario_desc(selected_scenario)
         if not ScenarioBase.can_handle_robot(self._scenario_name, self._robot_name):
             self._robot_name = self.find_valid_robot_name(self._scenario_name, self._robot_name, 1)
             self._robot_btn.text = self._robot_name


### PR DESCRIPTION
# Issue

- Button to change scenarios
  - This doesn't allow easily scanning all the available scenarios
  - It also only allows iterating through the list instead of jumping directly to the desired scenario
- Labels used for containing scenario and robot descriptions did not have word wrapping enabled
  - This meant the extension frame would expand width for long descriptions which disrupted positions of other items and added horizontal scrolling

![Screenshot from 2024-06-20 16-50-59](https://github.com/MikeWise2718/JakaControl/assets/2856501/6265b145-05d4-4ee4-a507-c843dcdbbe75)

# Solution

- Use ComboBox for Scenario list
  - Can scan all scenarios
  - Can directly choose scenario
- Enable word wrap on description Labels

![Screenshot from 2024-06-20 16-55-17](https://github.com/MikeWise2718/JakaControl/assets/2856501/cab29750-539b-4d39-adfb-0d89d832f732)

# Video

[Screencast from 06-20-2024 04:35:17 PM.webm](https://github.com/MikeWise2718/JakaControl/assets/2856501/626d4c35-362d-4671-acb4-4599afac02c4)




