### PR TITLE
fix: add self.ensure_orimat before using orimat

### DIFF
--- a/JakaCtrl/scenario_base.py
+++ b/JakaCtrl/scenario_base.py
@@ -507,6 +507,7 @@ class ScenarioBase:
             self.realize_joint_alarms_for_one(ridx, force=True)
         else:
             if rcfg.robmatskin == "default":
+                self.ensure_orimat()
                 # print("Reverting to original materials (default)")
                 apply_matdict_to_prim_and_children(self._stage, rcfg.orimat, rcfg.robot_prim_path)
             else:


### PR DESCRIPTION
## Issue

https://github.com/MikeWise2718/JakaControl/blob/103bb4ee01d30a674baeb26695b98af507cd2266/JakaCtrl/scenario_base.py#L546

Was not included in other place it was needed

## Solution

Add `self.ensure_orimat()` 

https://github.com/MikeWise2718/JakaControl/blob/103bb4ee01d30a674baeb26695b98af507cd2266/JakaCtrl/scenario_base.py#L509-L511

Fixes #41 